### PR TITLE
Separate chain calls

### DIFF
--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -28,11 +28,13 @@ final class MiddlewareDispatcherTest extends TestCase
     {
         $request = new ServerRequest('GET', '/');
 
-        $dispatcher = $this->createDispatcher()->withMiddlewares([
-            static function (): ResponseInterface {
-                return new Response(418);
-            },
-        ]);
+        $dispatcher = $this
+            ->createDispatcher()
+            ->withMiddlewares([
+                static function (): ResponseInterface {
+                    return new Response(418);
+                },
+            ]);
 
         $response = $dispatcher->dispatch($request, $this->getRequestHandler());
         $this->assertSame(418, $response->getStatusCode());
@@ -44,7 +46,9 @@ final class MiddlewareDispatcherTest extends TestCase
         $container = $this->createContainer([
             TestController::class => new TestController(),
         ]);
-        $dispatcher = $this->createDispatcher($container)->withMiddlewares([[TestController::class, 'index']]);
+        $dispatcher = $this
+            ->createDispatcher($container)
+            ->withMiddlewares([[TestController::class, 'index']]);
 
         $response = $dispatcher->dispatch($request, $this->getRequestHandler());
         $this->assertSame(200, $response->getStatusCode());
@@ -62,7 +66,9 @@ final class MiddlewareDispatcherTest extends TestCase
             return new Response(200, [], null, '1.1', implode($request->getAttributes()));
         };
 
-        $dispatcher = $this->createDispatcher()->withMiddlewares([$middleware1, $middleware2]);
+        $dispatcher = $this
+            ->createDispatcher()
+            ->withMiddlewares([$middleware1, $middleware2]);
 
         $response = $dispatcher->dispatch($request, $this->getRequestHandler());
         $this->assertSame(200, $response->getStatusCode());
@@ -80,7 +86,9 @@ final class MiddlewareDispatcherTest extends TestCase
             return new Response(200);
         };
 
-        $dispatcher = $this->createDispatcher()->withMiddlewares([$middleware1, $middleware2]);
+        $dispatcher = $this
+            ->createDispatcher()
+            ->withMiddlewares([$middleware1, $middleware2]);
 
         $response = $dispatcher->dispatch($request, $this->getRequestHandler());
         $this->assertSame(403, $response->getStatusCode());
@@ -99,7 +107,9 @@ final class MiddlewareDispatcherTest extends TestCase
             return new Response();
         };
 
-        $dispatcher = $this->createDispatcher(null, $eventDispatcher)->withMiddlewares([$middleware1, $middleware2]);
+        $dispatcher = $this
+            ->createDispatcher(null, $eventDispatcher)
+            ->withMiddlewares([$middleware1, $middleware2]);
         $dispatcher->dispatch($request, $this->getRequestHandler());
 
         $this->assertEquals(
@@ -121,7 +131,9 @@ final class MiddlewareDispatcherTest extends TestCase
         $request = new ServerRequest('GET', '/');
         $eventDispatcher = new SimpleEventDispatcher();
         $middleware = fn () => new FailMiddleware();
-        $dispatcher = $this->createDispatcher(null, $eventDispatcher)->withMiddlewares([$middleware]);
+        $dispatcher = $this
+            ->createDispatcher(null, $eventDispatcher)
+            ->withMiddlewares([$middleware]);
 
         try {
             $dispatcher->dispatch($request, $this->getRequestHandler());
@@ -151,7 +163,10 @@ final class MiddlewareDispatcherTest extends TestCase
     {
         self::assertSame(
             $expected,
-            $this->createDispatcher()->withMiddlewares($definitions)->hasMiddlewares()
+            $this
+                ->createDispatcher()
+                ->withMiddlewares($definitions)
+                ->hasMiddlewares()
         );
     }
 

--- a/tests/MiddlewareFactoryTest.php
+++ b/tests/MiddlewareFactoryTest.php
@@ -28,20 +28,26 @@ final class MiddlewareFactoryTest extends TestCase
     public function testCreateFromString(): void
     {
         $container = $this->getContainer([TestMiddleware::class => new TestMiddleware()]);
-        $middleware = $this->getMiddlewareFactory($container)->create(TestMiddleware::class);
+        $middleware = $this
+            ->getMiddlewareFactory($container)
+            ->create(TestMiddleware::class);
         self::assertInstanceOf(TestMiddleware::class, $middleware);
     }
 
     public function testCreateFromArray(): void
     {
         $container = $this->getContainer([TestController::class => new TestController()]);
-        $middleware = $this->getMiddlewareFactory($container)->create([TestController::class, 'index']);
+        $middleware = $this
+            ->getMiddlewareFactory($container)
+            ->create([TestController::class, 'index']);
         self::assertSame(
             'yii',
-            $middleware->process(
-                $this->createMock(ServerRequestInterface::class),
-                $this->createMock(RequestHandlerInterface::class)
-            )->getHeaderLine('test')
+            $middleware
+                ->process(
+                    $this->createMock(ServerRequestInterface::class),
+                    $this->createMock(RequestHandlerInterface::class)
+                )
+                ->getHeaderLine('test')
         );
         self::assertSame(
             [TestController::class, 'index'],
@@ -52,73 +58,91 @@ final class MiddlewareFactoryTest extends TestCase
     public function testCreateFromClosureResponse(): void
     {
         $container = $this->getContainer([TestController::class => new TestController()]);
-        $middleware = $this->getMiddlewareFactory($container)->create(
-            static function (): ResponseInterface {
-                return (new Response())->withStatus(418);
-            }
-        );
+        $middleware = $this
+            ->getMiddlewareFactory($container)
+            ->create(
+                static function (): ResponseInterface {
+                    return (new Response())->withStatus(418);
+                }
+            );
         self::assertSame(
             418,
-            $middleware->process(
-                $this->createMock(ServerRequestInterface::class),
-                $this->createMock(RequestHandlerInterface::class)
-            )->getStatusCode()
+            $middleware
+                ->process(
+                    $this->createMock(ServerRequestInterface::class),
+                    $this->createMock(RequestHandlerInterface::class)
+                )
+                ->getStatusCode()
         );
     }
 
     public function testCreateFromClosureMiddleware(): void
     {
         $container = $this->getContainer([TestController::class => new TestController()]);
-        $middleware = $this->getMiddlewareFactory($container)->create(
-            static function (): MiddlewareInterface {
-                return new TestMiddleware();
-            }
-        );
+        $middleware = $this
+            ->getMiddlewareFactory($container)
+            ->create(
+                static function (): MiddlewareInterface {
+                    return new TestMiddleware();
+                }
+            );
         self::assertSame(
             '42',
-            $middleware->process(
-                $this->createMock(ServerRequestInterface::class),
-                $this->createMock(RequestHandlerInterface::class)
-            )->getHeaderLine('test')
+            $middleware
+                ->process(
+                    $this->createMock(ServerRequestInterface::class),
+                    $this->createMock(RequestHandlerInterface::class)
+                )
+                ->getHeaderLine('test')
         );
     }
 
     public function testCreateWithUseParamsMiddleware(): void
     {
         $container = $this->getContainer([UseParamsMiddleware::class => new UseParamsMiddleware()]);
-        $middleware = $this->getMiddlewareFactory($container)->create(UseParamsMiddleware::class);
+        $middleware = $this
+            ->getMiddlewareFactory($container)
+            ->create(UseParamsMiddleware::class);
 
         self::assertSame(
             'GET',
-            $middleware->process(
-                new ServerRequest('GET', '/'),
-                $this->getRequestHandler()
-            )->getHeaderLine('method')
+            $middleware
+                ->process(
+                    new ServerRequest('GET', '/'),
+                    $this->getRequestHandler()
+                )
+                ->getHeaderLine('method')
         );
     }
 
     public function testCreateWithUseParamsController(): void
     {
         $container = $this->getContainer([UseParamsController::class => new UseParamsController()]);
-        $middleware = $this->getMiddlewareFactory($container)->create([UseParamsController::class, 'index']);
+        $middleware = $this
+            ->getMiddlewareFactory($container)
+            ->create([UseParamsController::class, 'index']);
 
         self::assertSame(
             'GET',
-            $middleware->process(
-                new ServerRequest('GET', '/'),
-                $this->getRequestHandler()
-            )->getHeaderLine('method')
+            $middleware
+                ->process(
+                    new ServerRequest('GET', '/'),
+                    $this->getRequestHandler()
+                )
+                ->getHeaderLine('method')
         );
     }
 
     public function testInvalidMiddlewareWithWrongCallable(): void
     {
         $container = $this->getContainer([TestController::class => new TestController()]);
-        $middleware = $this->getMiddlewareFactory($container)->create(
-            static function () {
-                return 42;
-            }
-        );
+        $middleware = $this
+            ->getMiddlewareFactory($container)
+            ->create(
+                static function () {
+                    return 42;
+                }
+            );
 
         $this->expectException(InvalidMiddlewareDefinitionException::class);
         $middleware->process(
@@ -130,26 +154,34 @@ final class MiddlewareFactoryTest extends TestCase
     public function testInvalidMiddlewareWithWrongInstance(): void
     {
         $this->expectException(InvalidMiddlewareDefinitionException::class);
-        $this->getMiddlewareFactory()->create(new stdClass());
+        $this
+            ->getMiddlewareFactory()
+            ->create(new stdClass());
     }
 
     public function testInvalidMiddlewareWithWrongString(): void
     {
         $this->expectException(InvalidMiddlewareDefinitionException::class);
-        $this->getMiddlewareFactory()->create('test');
+        $this
+            ->getMiddlewareFactory()
+            ->create('test');
     }
 
     public function testInvalidMiddlewareWithWrongClass(): void
     {
         $this->expectException(InvalidMiddlewareDefinitionException::class);
         $this->expectExceptionMessage('Parameter should be either PSR middleware class name or a callable.');
-        $this->getMiddlewareFactory()->create(TestController::class);
+        $this
+            ->getMiddlewareFactory()
+            ->create(TestController::class);
     }
 
     public function testInvalidMiddlewareWithWrongController(): void
     {
         $container = $this->getContainer([InvalidController::class => new InvalidController()]);
-        $middleware = $this->getMiddlewareFactory($container)->create([InvalidController::class, 'index']);
+        $middleware = $this
+            ->getMiddlewareFactory($container)
+            ->create([InvalidController::class, 'index']);
 
         $this->expectException(InvalidMiddlewareDefinitionException::class);
         $middleware->process(
@@ -161,31 +193,41 @@ final class MiddlewareFactoryTest extends TestCase
     public function testInvalidMiddlewareWithWrongArraySize(): void
     {
         $this->expectException(InvalidMiddlewareDefinitionException::class);
-        $this->getMiddlewareFactory()->create(['test']);
+        $this
+            ->getMiddlewareFactory()
+            ->create(['test']);
     }
 
     public function testInvalidMiddlewareWithWrongArrayClass(): void
     {
         $this->expectException(InvalidMiddlewareDefinitionException::class);
-        $this->getMiddlewareFactory()->create(['class', 'test']);
+        $this
+            ->getMiddlewareFactory()
+            ->create(['class', 'test']);
     }
 
     public function testInvalidMiddlewareWithWrongArrayType(): void
     {
         $this->expectException(InvalidMiddlewareDefinitionException::class);
-        $this->getMiddlewareFactory()->create(['class' => TestController::class, 'index']);
+        $this
+            ->getMiddlewareFactory()
+            ->create(['class' => TestController::class, 'index']);
     }
 
     public function testInvalidMiddlewareWithWrongArrayWithInstance(): void
     {
         $this->expectException(InvalidMiddlewareDefinitionException::class);
-        $this->getMiddlewareFactory()->create([new TestController(), 'index']);
+        $this
+            ->getMiddlewareFactory()
+            ->create([new TestController(), 'index']);
     }
 
     public function testInvalidMiddlewareWithWrongArrayWithIntItems(): void
     {
         $this->expectException(InvalidMiddlewareDefinitionException::class);
-        $this->getMiddlewareFactory()->create([7, 42]);
+        $this
+            ->getMiddlewareFactory()
+            ->create([7, 42]);
     }
 
     private function getMiddlewareFactory(ContainerInterface $container = null): MiddlewareFactoryInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Readability fix  | according to https://github.com/yiisoft/docs/issues/155, chain calls must be put on separate lines.