### PR TITLE
Support request handler from closure factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Enh #95: Raise minimum PHP version to `^8.1` and make all possible properties readonly (@xepozz)
 - Chg #106: Change PHP constraint in `composer.json` to `8.1 - 8.4` (@vjik)
 - Enh #106: Mark `MiddlewareStack::$fallbackHandler` readonly (@vjik)
-- Enh #108: Add support for closures that returns `Psr\Http\Server\RequestHandlerInterface` (@rustamwin)
+- New #108: Support callable that returns `Psr\Http\Server\RequestHandlerInterface` as middleware definition (@rustamwin)
 
 ## 5.2.0 September 25, 2023
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Enh #95: Raise minimum PHP version to `^8.1` and make all possible properties readonly (@xepozz)
 - Chg #106: Change PHP constraint in `composer.json` to `8.1 - 8.4` (@vjik)
 - Enh #106: Mark `MiddlewareStack::$fallbackHandler` readonly (@vjik)
+- Enh #108: Add support for closures that returns `Psr\Http\Server\RequestHandlerInterface` (@rustamwin)
 
 ## 5.2.0 September 25, 2023
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ In the above we have used a callback. Overall the following options are availabl
   ```
 
   The middleware returned will be executed.
+- A function returning a request handler such as
+
+  ```php
+  static function (): RequestHandlerInterface {
+      return new SimpleRequestHandler();
+  }
+  ```
+
+  The request handler returned will be executed.
 - A callback `function(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface`.
 - An array definition (see [syntax](https://github.com/yiisoft/definitions#arraydefinition)) of middleware:
 

--- a/src/InvalidMiddlewareDefinitionException.php
+++ b/src/InvalidMiddlewareDefinitionException.php
@@ -91,6 +91,14 @@ final class InvalidMiddlewareDefinitionException extends InvalidArgumentExceptio
         }
         ```
 
+        Closure that returns `RequestHandlerInterface`:
+
+        ```php
+        static function (): RequestHandlerInterface {
+            return new SimpleRequestHandler();
+        }
+        ```
+
         Action in controller:
 
         ```php

--- a/src/MiddlewareFactory.php
+++ b/src/MiddlewareFactory.php
@@ -215,6 +215,9 @@ final class MiddlewareFactory
                 if ($response instanceof MiddlewareInterface) {
                     return $response->process($request, $handler);
                 }
+                if ($response instanceof RequestHandlerInterface) {
+                    return $response->handle($request);
+                }
 
                 throw new InvalidMiddlewareDefinitionException($this->callback);
             }

--- a/tests/MiddlewareFactoryTest.php
+++ b/tests/MiddlewareFactoryTest.php
@@ -185,6 +185,25 @@ final class MiddlewareFactoryTest extends TestCase
         );
     }
 
+    public function testCreateFromClosureRequestHandler(): void
+    {
+        $container = $this->getContainer([TestController::class => new TestController()]);
+        $middleware = $this
+            ->getMiddlewareFactory($container)
+            ->create(
+                static fn(): RequestHandlerInterface => new SimpleRequestHandler()
+            );
+        self::assertSame(
+            200,
+            $middleware
+                ->process(
+                    $this->createMock(ServerRequestInterface::class),
+                    $this->createMock(RequestHandlerInterface::class)
+                )
+                ->getStatusCode()
+        );
+    }
+
     public function testCreateWithUseParamsMiddleware(): void
     {
         $container = $this->getContainer([UseParamsMiddleware::class => new UseParamsMiddleware()]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -

After changing middlewares to request handlers these routes are broken: https://github.com/yiisoft/app-api/blob/f34c48e282ccc2f24f2c224e0bc4ba5643287c66/config/common/routes.php#L25